### PR TITLE
Fix missing items in groups

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,9 @@ var CollectionView = React.createClass({
         var itemsGroups = [];
         var group = [];
         items.forEach(function(item) {
-          if (group.length == itemsPerRow) {
+          if (group.length === itemsPerRow) {
             itemsGroups.push(group);
-            group = [];
+            group = [item];
           } else {
             group.push(item);
           }


### PR DESCRIPTION
When building the groups of items, every time a group's size became
equal with the `itemsPerRow` count - it pushes that group onto the
`itemGroups` array.

In the initial implementation - every 4th item was getting lost in the
`forEach` loop.
