### PR TITLE
Update react-native dependency to work with later versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/lucholaf/react-native-grid-view",
   "dependencies": {
-    "react-native": "^0.4.0"
+    "react-native": ">=0.4.0"
   }
 }


### PR DESCRIPTION
I encountered problems when updating to react-native 0.6.0 in an application that has react-native-grid-view as a dependency. react-native-grid-view seems to be working fine in 0.6.0 so I've updated the dependency in package.json, which resolves the conflict.
