### PR TITLE
Move react-native to a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/lucholaf/react-native-grid-view/issues"
   },
   "homepage": "https://github.com/lucholaf/react-native-grid-view",
-  "dependencies": {
+  "peerDependencies": {
     "react-native": ">=0.4.0"
   }
 }


### PR DESCRIPTION
Having react-native as a hard dependency can cause the react native package manager to load multiple versions of react-native into an application. Moving it to a peer dependency resolves this and allows the package manager to raise a warning if the application doesn't already depend on a compatible version of react-native.
