### PR TITLE
Pass the index of each element to the renderItem method. This way it …

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ var CollectionView = React.createClass({
     },
     renderGroup: function(group) {
       var that = this;
-      var items = group.map(function(item) {
-        return that.props.renderItem(item);
+      var items = group.map(function(item, index) {
+        return that.props.renderItem(item, index);
       });
       return (
         <View style={styles.group}>


### PR DESCRIPTION
…is possible to prevent react-native from throwing warnings that no  are no unique key for items in an array.

Now we can create our renderItem method like this:

`_renderItem(item, index){
        return <Image source={item.preview} key={index}/>
    }`

react-native now stops complaining about the key property.
