### PR TITLE
Pass props to the list view

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,12 +46,9 @@ var CollectionView = React.createClass({
         var groups = this.groupItems(this.props.items, this.props.itemsPerRow);
         var ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
         return (<ListView
-          dataSource={ds.cloneWithRows(groups)}
+          {...this.props}
           renderRow={this.renderGroup}
-          style={this.props.style}
-          onEndReached={this.props.onEndReached}
-          scrollEnabled={this.props.scrollEnabled}
-          pageSize={this.props.pageSize | 1}
+          dataSource={ds.cloneWithRows(groups)}
         />);
     },
 });


### PR DESCRIPTION
Passing props from the GridView to the ListView we allow to set all actual and future list view properties and don't restrict usage of GridView at specific case (for example: GridView don't support renderHeader currently).

Fix #18
