### PR TITLE
Clean grid

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 var React = require('react-native');
 
 var {
-  AppRegistry,
   View,
   StyleSheet,
   ListView,
@@ -23,6 +22,11 @@ var CollectionView = React.createClass({
         });
 
         if (group.length > 0) {
+          if (this.props.cleanGrid == true) {
+            while (group.length < itemsPerRow) {
+              group.push(null);
+            }
+          }
           itemsGroups.push(group);
         }
 


### PR DESCRIPTION
Use solution proposed by @bradynapier. This solution call `renderItem` function with null data so `renderItem` need to handle this case by just return an empty view with a style set to `{flex: 1}`.

We could also handle this case in the `renderGroup` using the implementation below:

``` javascript
renderGroup: function(group) {
    let items = group.map((item, index) => {
        return item == null
            ? <View style={{flex: 1}} />
            : that.props.renderItem(item, index);
    });
    return <View style={styles.group}>{items}</View>;
}
```

Fix #12
